### PR TITLE
Reuse organization property in package name

### DIFF
--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -1,7 +1,7 @@
 pluginName=Foo Bar
 name=sbt-$pluginName;format="norm"$
 organization=org.example
-package=org.example.sbt
+package=$organization;format="lower,package"$.sbt
 purpose=An sbt AutoPlugin
 description=sbt AutoPlugin seed
 verbatim=.travis.yml


### PR DESCRIPTION
This is just to reuse the `organization` in the `package` name to prevent having to type it twice. I also added `organizationName` while I was at it since it is unlikely that one would use a reverse domain name as the github organization name.